### PR TITLE
Broaden the test regex

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -6,7 +6,7 @@ task 'generate', "Generate Jest preset JSON config.", =>
   preset =
     moduleFileExtensions: [ 'js', 'json', coffee... ]
     transform: "#{glob}": process.env.npm_package_name
-    testRegex: "tests?/.*\\.(#{glob})$"
+    testRegex: "(tests?)?/.*\\.(#{glob})$"
     testPathIgnorePatterns: [ 'node_modules', 'fixtures' ]
 
   # coffeelint: disable=no_debugger


### PR DESCRIPTION
Not everyone stores files in a `tests?` path e.g. some folks classify them with `*.test.coffee` or `*.spec.coffee`.