### PR TITLE
Fix/unexpected token z

### DIFF
--- a/jest-preset.coffee
+++ b/jest-preset.coffee
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
-import {compile, helpers as h, FILE_EXTENSIONS} from 'coffeescript'
+import { FILE_EXTENSIONS} from 'coffeescript'
+import { transform } from '@babel/core'
 
 coffee = FILE_EXTENSIONS.map (ext) => ext[1..]
 
@@ -13,17 +14,5 @@ module.exports =
   moduleFileExtensions: ['js', 'json', coffee...]
   testMatch: ["<rootDir>/*@(test|spec)?(s){/**/,}*.@(#{coffee.join '|'})"]
   testPathIgnorePatterns: ['node_modules', 'fixtures']
-  transform: [coffee.join '|']: __filename
+  transform: [coffee.join '|']: path.join __dirname, 'transform-coffee'
   setupFilesAfterEnv: [__filename ]
-
-  process: (source, file) =>
-    return source unless h.isCoffee file
-
-    if h.isLiterate file
-      source = h.invertLiterate source
-
-    transpile =
-      plugins: ['@babel/transform-modules-commonjs']
-      presets: ['jest']
-
-    compile source, { bare: true, inlineMap: true, transpile }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "test": "npm run test.lint && npm run test.jest --",
     "test.lint": "npm run test.lint.coffee",
     "test.lint.coffee": "coffeelint -- *.coffee test/*.*coffee*",
-    "test.jest": "jest --verbose ${GITHUB_ACTIONS+--all --ci --no-cache}",
+    "test.jest": "jest ${GITHUB_ACTIONS+--all --ci --no-cache}",
     "clean": "rm -f *.js & jest --clearCache --config {}"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,21 +21,21 @@
     "coffeelint": "^2.1.0",
     "coffeescript": "^2.5.1",
     "husky": "^4.3.0",
-    "jest": "^26.5.3",
-    "jest-config": "^26.5.3",
-    "jest-validate": "^26.5.3",
-    "lint-staged": "^10.4.0",
+    "jest": "^27.0.0",
+    "jest-config": "^27.0.0",
+    "jest-validate": "^27.0.0",
+    "lint-staged": "^14.0.0",
     "micromatch": "^4.0.2"
   },
   "dependencies": {
     "@babel/core": "^7.12.1",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-    "babel-preset-jest": "^26.5.0",
-    "source-map-support": "danielbayley/node-source-map-support#patch-1"
+    "babel-preset-jest": "^27.0.0",
+    "source-map-support": "^0.5.21"
   },
   "peerDependencies": {
     "coffeescript": "2.x",
-    "jest": ">= 25.0.0 < 27"
+    "jest": ">= 27.0.0 < 30"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -82,7 +82,7 @@
     "test": "npm run test.lint && npm run test.jest --",
     "test.lint": "npm run test.lint.coffee",
     "test.lint.coffee": "coffeelint -- *.coffee test/*.*coffee*",
-    "test.jest": "jest ${GITHUB_ACTIONS+--all --ci --no-cache}",
+    "test.jest": "jest --verbose ${GITHUB_ACTIONS+--all --ci --no-cache}",
     "clean": "rm -f *.js & jest --clearCache --config {}"
   }
 }

--- a/test/preset.coffee
+++ b/test/preset.coffee
@@ -4,6 +4,7 @@ import {defaults as exampleConfig} from 'jest-config'
 import {validate, multipleValidOptions} from 'jest-validate'
 import {isMatch} from 'micromatch'
 import preset from '..'
+import transformCoffee from '../transform-coffee'
 import {main} from '../package'#.json
 
 describe main[2..], =>
@@ -15,13 +16,14 @@ describe main[2..], =>
     expect(isValid).toBe true
 
   it "exports a #{process} method", =>
-    expect(preset).toMatchObject process: expect.any Function
+    expect(transformCoffee).toMatchObject process: expect.any Function
 
   describe "CoffeeScript", =>
     it "transforms #{extname __filename} files", =>
       source = '=>'
-      js = compile source, bare: true
-      expect(preset.process source, __filename).toMatch RegExp js
+      js = compile source, bare: true, header: false
+      transformed = transformCoffee.process source, __filename
+      expect(transformed.code).toMatch RegExp js
 
     it "works with Promises/await", =>
       n = await new Promise (resolve) => resolve 1

--- a/transform-coffee.coffee
+++ b/transform-coffee.coffee
@@ -1,0 +1,27 @@
+{compile, helpers: h, FILE_EXTENSIONS} = require('coffeescript')
+babel = require('@babel/core')
+transform = babel.transform
+
+module.exports =
+  process: (source, file) =>
+    return source unless h.isCoffee file
+
+    if h.isLiterate file
+      source = h.invertLiterate source
+
+    coffeeCompiled = compile source,
+      bare: true
+      sourceMap: true
+      filename: file
+      header: false
+
+
+    transpile =
+      plugins: ['@babel/transform-modules-commonjs']
+      presets: ['jest']
+      sourceMaps: 'inline'
+      inputSourceMap: JSON.parse coffeeCompiled.v3SourceMap
+    
+    # jest >= 27.x expects babel return format
+    # { code, map, ast }
+    transform coffeeCompiled.js, transpile


### PR DESCRIPTION
The error reported in an unexpected token z issue occurs not only in this package for jest, but I also encountered this error using the coffeescript build API using the transpilation option in other projects, according to the coffeescript doc the resulting code javascript can be passed untranspiled to other transpilation methods, so separate the responsibilities between the coffeescript compiler and the babel transpiler this way the error does not occur.

PS: Could this be an error that only occurs with the coffeescript compiler using the API? It is a hypothesis since it does not occur using the compiler as a coffee -ct command.